### PR TITLE
#3 Quick fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.user
-deubg
+debug
 Makefile
 release
+/doc/doxygen/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for example), but that is not officially supported (might become so, if enough p
 Note, the library will soon depend on Qt5's built-in JSON support, so it is unlikely that libqtaws will ever officially
 support earlier version of Qt, such as Qt4.8.
 
-## API Documentaion
+## API Documentation
 
 See the doxygen-generated [API documentation](http://pcolby.github.io/libqtaws/doc/api/annotated.html).
 

--- a/src/core/awsendpoint.cpp
+++ b/src/core/awsendpoint.cpp
@@ -514,8 +514,8 @@ void AwsEndpointPrivate::loadEndpointData(QXmlStreamReader &xml)
     }
     Q_ASSERT(!xml.hasError());
     Q_ASSERT(!hosts.isEmpty());
-    Q_ASSERT(!regions.hasError());
-    Q_ASSERT(!services.hasError());
+    Q_ASSERT(!regions.isEmpty());
+    Q_ASSERT(!services.isEmpty());
 }
 
 /**

--- a/src/core/awsendpoint.cpp
+++ b/src/core/awsendpoint.cpp
@@ -514,8 +514,8 @@ void AwsEndpointPrivate::loadEndpointData(QXmlStreamReader &xml)
     }
     Q_ASSERT(!xml.hasError());
     Q_ASSERT(!hosts.isEmpty());
-//    Q_ASSERT(!regions.hasError());
-//    Q_ASSERT(!services.hasError());
+    Q_ASSERT(!regions.hasError());
+    Q_ASSERT(!services.hasError());
 }
 
 /**

--- a/src/core/awsendpoint.cpp
+++ b/src/core/awsendpoint.cpp
@@ -514,8 +514,8 @@ void AwsEndpointPrivate::loadEndpointData(QXmlStreamReader &xml)
     }
     Q_ASSERT(!xml.hasError());
     Q_ASSERT(!hosts.isEmpty());
-    Q_ASSERT(!regions.hasError());
-    Q_ASSERT(!services.hasError());
+//    Q_ASSERT(!regions.hasError());
+//    Q_ASSERT(!services.hasError());
 }
 
 /**

--- a/src/core/awsendpoint.h
+++ b/src/core/awsendpoint.h
@@ -17,8 +17,8 @@
     along with libqtaws.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef AWSSENDPOINT_H
-#define AWSSENDPOINT_H
+#ifndef AWSENDPOINT_H
+#define AWSENDPOINT_H
 
 #include "qtawsglobal.h"
 

--- a/src/core/awsregion.cpp
+++ b/src/core/awsregion.cpp
@@ -143,7 +143,7 @@ QString AwsRegion::name(const Region &region)
         case US_West_1:      return QLatin1String("us-west-1");
         case US_West_2:      return QLatin1String("us-west-2");
         default:
-            Q_ASSERT_X(false, "AwsRegion::name", QString::fromLatin1("invalid region: %1").arg(region));
+            Q_ASSERT_X(false, "AwsRegion::name", qPrintable(QString::fromLatin1("invalid region: %1").arg(region)));
     }
     return QString();
 }
@@ -200,7 +200,7 @@ QString AwsRegion::fullName(const Region &region)
         case US_West_1:      return QLatin1String("US West (Northern California) Region");
         case US_West_2:      return QLatin1String("US West (Oregon) Region");
         default:
-            Q_ASSERT_X(false, "AwsRegion::fullName", QString::fromLatin1("invalid region: %1").arg(region));
+            Q_ASSERT_X(false, "AwsRegion::fullName", qPrintable(QString::fromLatin1("invalid region: %1").arg(region)));
     }
     return QString();
 }
@@ -269,7 +269,7 @@ AwsRegion::Region AwsRegion::fromName(const QString &regionName)
     if (lowerName == QLatin1String("us-gov-west-1"))  return US_Gov_West_1;
     if (lowerName == QLatin1String("us-west-1"))      return US_West_1;
     if (lowerName == QLatin1String("us-west-2"))      return US_West_2;
-    Q_ASSERT_X(false, "AwsRegion::fromName", QString::fromLatin1("invalid region name: %1").arg(regionName));
+    Q_ASSERT_X(false, "AwsRegion::fromName", qPrintable(QString::fromLatin1("invalid region name: %1").arg(regionName)));
     return InvalidRegion;
 }
 

--- a/src/core/awsregion_p.h
+++ b/src/core/awsregion_p.h
@@ -17,8 +17,8 @@
     along with libqtaws.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef AWSSIGNATUREV4_P_H
-#define AWSSIGNATUREV4_P_H
+#ifndef AWSREGION_P_H
+#define AWSREGION_P_H
 
 #include "qtawsglobal.h"
 

--- a/src/core/awssignaturev0.h
+++ b/src/core/awssignaturev0.h
@@ -17,8 +17,8 @@
     along with libqtaws.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef AwsSignatureV0_H
-#define AwsSignatureV0_H
+#ifndef AWSSIGNATUREV0_H
+#define AWSSIGNATUREV0_H
 
 #include "qtawsglobal.h"
 #include "awsabstractsignature.h"

--- a/src/core/awssignaturev0_p.h
+++ b/src/core/awssignaturev0_p.h
@@ -17,8 +17,8 @@
     along with libqtaws.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef AwsSignatureV0_P_H
-#define AwsSignatureV0_P_H
+#ifndef AWSSIGNATUREV0_P_H
+#define AWSSIGNATUREV0_P_H
 
 #include "qtawsglobal.h"
 #include "awsabstractsignature_p.h"


### PR DESCRIPTION
Fix spelling.
Add doxygen directory to .gitignore.
Fix Windows casting error by using qPrintable().
Fix build, probably a copy/paste error.
Fix header #define.